### PR TITLE
Change package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,34 +13,34 @@ Just trying to fix the release workflow! Tweaking 👨‍💻
 ## v1.4.0
 
 ### What's Changed
-* Update AddRefererToSessionStorage.php by @jamesmpigott in https://github.com/steadfast-collective/convertkit/pull/5
+* Update AddRefererToSessionStorage.php by @jamesmpigott in https://github.com/steadfast-collective/statamic-convertkit/pull/5
 
-**Full Changelog**: https://github.com/steadfast-collective/convertkit/compare/v1.3...v1.4
+**Full Changelog**: https://github.com/steadfast-collective/statamic-convertkit/compare/v1.3...v1.4
 
 ## v1.3.0
 
 ### What's Changed
-* Move to vite asset building by @jamesmpigott in https://github.com/steadfast-collective/convertkit/pull/3
-* Statamic 4 compatibility by @jamesmpigott in https://github.com/steadfast-collective/convertkit/pull/4
+* Move to vite asset building by @jamesmpigott in https://github.com/steadfast-collective/statamic-convertkit/pull/3
+* Statamic 4 compatibility by @jamesmpigott in https://github.com/steadfast-collective/statamic-convertkit/pull/4
 
-**Full Changelog**: https://github.com/steadfast-collective/convertkit/compare/v1.2...v1.3
+**Full Changelog**: https://github.com/steadfast-collective/statamic-convertkit/compare/v1.2...v1.3
 
 ## v1.2.0
 
 ### What's Changed
-* Fix return typehinting by @jamesmpigott in https://github.com/steadfast-collective/convertkit/pull/2
+* Fix return typehinting by @jamesmpigott in https://github.com/steadfast-collective/statamic-convertkit/pull/2
 
-**Full Changelog**: https://github.com/steadfast-collective/convertkit/compare/v1.1...v1.2
+**Full Changelog**: https://github.com/steadfast-collective/statamic-convertkit/compare/v1.1...v1.2
 
 ## v1.1.0
 
 ### What's Changed
-* Fix fatal error when custom field key is not defined by @jamesmpigott in https://github.com/steadfast-collective/convertkit/pull/1
+* Fix fatal error when custom field key is not defined by @jamesmpigott in https://github.com/steadfast-collective/statamic-convertkit/pull/1
 
 ### New Contributors
-* @jamesmpigott made their first contribution in https://github.com/steadfast-collective/convertkit/pull/1
+* @jamesmpigott made their first contribution in https://github.com/steadfast-collective/statamic-convertkit/pull/1
 
-**Full Changelog**: https://github.com/steadfast-collective/convertkit/compare/1.0...v1.1
+**Full Changelog**: https://github.com/steadfast-collective/statamic-convertkit/compare/1.0...v1.1
 
 ## v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add Subscribers via Statamic forms.
 You can search for this addon in the `Tools > Addons` section of the Statamic control panel and click **install**, or run the following command from your project root:
 
 ``` bash
-composer require steadfast-collective/convertkit
+composer require steadfast-collective/statamic-convertkit
 ```
 
 Add your ConvertKit API key to `.env`

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "steadfast-collective/convertkit",
+    "name": "steadfast-collective/statamic-convertkit",
     "autoload": {
         "psr-4": {
             "SteadfastCollective\\ConvertKit\\": "src"
@@ -16,7 +16,7 @@
             ]
         },
         "download-dist": {
-            "url": "https://github.com/steadfast-collective/convertkit/releases/download/{$version}/dist.tar.gz",
+            "url": "https://github.com/steadfast-collective/statamic-convertkit/releases/download/{$version}/dist.tar.gz",
             "path": "dist"
         }
     },


### PR DESCRIPTION
This pull request slightly changes the package name from `steadfast-collective/convertkit` to `steadfast-collective/statamic-convertkit`. I basically just added the `statamic-` prefix.

In the future, in the case we ever create a Laravel package for ConvertKit, we would name it `laravel-convertkit`.