### PR TITLE
Setup Laravel Pint action

### DIFF
--- a/.github/workflows/pint-fix.yaml
+++ b/.github/workflows/pint-fix.yaml
@@ -1,0 +1,29 @@
+name: Fix PHP code style issues
+
+on:
+  push:
+    paths:
+      - '**.php'
+
+permissions:
+  contents: write
+
+jobs:
+  fix-php-code-styling:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'steadfast-collective'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.PINT }}
+
+      - name: Fix PHP code style issues
+        uses: aglipanci/laravel-pint-action@1.0.0
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Fix styling

--- a/.github/workflows/pint-lint.yaml
+++ b/.github/workflows/pint-lint.yaml
@@ -1,0 +1,20 @@
+name: Lint PHP code style issues
+
+on:
+  pull_request:
+    paths:
+      - '**.php'
+
+jobs:
+  lint-php-code-styling:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check PHP code style issues
+        uses: aglipanci/laravel-pint-action@1.0.0
+        with:
+          testMode: true
+          verboseMode: true

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,11 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "class_attributes_separation": {
+            "elements": {
+                "method": "one"
+            }
+        },
+        "psr_autoloading": true
+    }
+}


### PR DESCRIPTION
This pull request sets up a GitHub Action for running Laravel Pint on PRs. 

I've had to do this differently to how we do it for private projects because we need contributors to make fixes themselves, due to the way GitHub branch permissions work.